### PR TITLE
Add lxml as a project requirement

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: patch
+
+*bug*: Add [lxml](https://lxml.de/) as a project requirement. It is used to
+parse Atom and RSS feeds.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,10 @@ classifiers = [
 python = "^3.6.2 || ^3.7"
 pelican = "^3 || ^4"
 markdown = {version = "^3.2", optional = true}
-beautifulsoup4 = "^4.9.3"
+beautifulsoup4 = "^4.9"
 six = "^1.15.0"
-Pillow = "^8.0.1"
+Pillow = "^8.0"
+lxml = "^4.6"
 
 [tool.poetry.dev-dependencies]
 black = {version = "^21.4b2", allow-prereleases = true}


### PR DESCRIPTION
Closes #43. Required by to process feed images.