### PR TITLE
Support devel 'unknown' pelican version

### DIFF
--- a/pelican/plugins/image_process/image_process.py
+++ b/pelican/plugins/image_process/image_process.py
@@ -29,7 +29,6 @@ from pelican import signals
 log = logging.getLogger(__name__)
 
 IMAGE_PROCESS_REGEX = re.compile("image-process-[-a-zA-Z0-9_]+")
-PELICAN_MAJOR_VERSION = int(pelican_version.split(".")[0])
 
 Path = collections.namedtuple("Path", ["base_url", "source", "base_path", "filename"])
 
@@ -376,7 +375,7 @@ def compute_paths(img, settings, derivative):
         posixpath.dirname(img["src"]), pathname2url(derivative_path)
     )
 
-    if PELICAN_MAJOR_VERSION < 4:
+    if pelican_version != "unknown" and int(pelican_version.split(".")[0]) < 4:
         file_paths = settings["filenames"]
     else:
         file_paths = settings["static_content"]


### PR DESCRIPTION
When using a development version of pelican, the version is set to
'unknown'. However, this cannot be parsed as an integer, and results in
failure:

	ValueError: invalid literal for int() with base 10: 'unknown'

The proposed fix is to consider 'unknown' version as a >=4 version. The
global variable has been moved into the if statement instead, so that
lazy evaluation avoids the cast to an integer if the version is not
known.