### PR TITLE
Update black to 22.1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.1.0
     hooks:
       - id: black
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ Pillow = "^8.0"
 lxml = "^4.6"
 
 [tool.poetry.dev-dependencies]
-black = {version = "^21.4b2", allow-prereleases = true}
+black = "^22"
 flake8 = "^3.8"
 flake8-black = "^0.2.0"
 invoke = "^1.3"


### PR DESCRIPTION
Updates both the pre-commit configuration and the poetry configuration.
Closes #56.