### PR TITLE
Don't crash on empty <content> elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 CHANGELOG
 =========
 
+3.0.0 - 2022-03-19
+------------------
+
+*support*: Drops support for Python 3.6.
+
+*support*: upgrade Pillow to 9.0.0 (which doesn't support Python 3.6)
+
+*support* regenerate test images to match new output from Pillow 9
+
 2.1.3 - 2021-07-09
 ------------------
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,0 @@
-Release type: major
-
-*support*: Drops support for Python 3.6.
-
-*support*: upgrade Pillow to 9.0.0 (which doesn't support Python 3.6)
-
-*support* regenerate test images to match new output from Pillow 9

--- a/pelican/plugins/image_process/image_process.py
+++ b/pelican/plugins/image_process/image_process.py
@@ -299,7 +299,7 @@ def harvest_feed_images(path, context, feed):
         soup = BeautifulSoup(f, "xml")
 
         for content in soup.find_all("content"):
-            if content["type"] != "html":
+            if content["type"] != "html" or not content.string:
                 continue
 
             doc = html.unescape(content.string)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pelican-image-process"
-version = "2.1.3"
+version = "3.0.0"
 description = "Pelican plugin that automates image processing."
 authors = ["Pelican Dev Team <authors@getpelican.com>"]
 license = "AGPL-3.0"


### PR DESCRIPTION
Pelican emits an empty `<content>` element to the Atom feed for empty articles. Beautiful Soup's `string` attribute returns `None` for empty elements, not the empty string.

Fix a crash in `harvest_feed_images()` when this happens.