### PR TITLE
Add 'link_original' pseudo-transform to link to the original file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 CHANGELOG
 =========
 
+3.0.0 - 2022-03-19
+------------------
+
+*support*: Drops support for Python 3.6.
+
+*support*: upgrade Pillow to 9.0.0 (which doesn't support Python 3.6)
+
+*support* regenerate test images to match new output from Pillow 9
+
 2.1.3 - 2021-07-09
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -421,6 +421,34 @@ IMAGE_PROCESS = {
 }
 ```
 
+### Linking The Original Image
+
+To wrap the new `<img>` tag in a `<a>` that links to the original image file, add `link_original`. For plain images, add `link_original` directly in the list of image transformations. For example:
+
+```python
+IMAGE_PROCESS = {
+    "thumb": [ "scale_in 80 80 True", "link_original" ],
+}
+```
+
+For `response-image`, add `link_original` as a "truthy" value in the dictionary. For example:
+
+``` python
+IMAGE_PROCESS = {
+    "article-image": {
+        "type": "responsive-image",
+        "srcset": [
+            ("1x", ["scale_in 500 500 False"]),
+            ("2x", ["scale_in 1000 1000 False"]),
+        ],
+        "default": "1x",
+        "link_original": True,
+    },
+}
+```
+
+For `<picture>` tags, `link_original` is not currently supported.
+
 ### Additional Settings
 
 #### Destination Directory

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,0 @@
-Release type: major
-
-*support*: Drops support for Python 3.6.
-
-*support*: upgrade Pillow to 9.0.0 (which doesn't support Python 3.6)
-
-*support* regenerate test images to match new output from Pillow 9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pelican-image-process"
-version = "2.1.3"
+version = "3.0.0"
 description = "Pelican plugin that automates image processing."
 authors = ["Pelican Dev Team <authors@getpelican.com>"]
 license = "AGPL-3.0"


### PR DESCRIPTION
Thanks for this plugin, it makes image management very convenient!

I wanted to link most of my images back to the full-sized source, so I've added `link_original` as a kind of "pseudo-transform" feature. Please let me know if you think this is useful. 

Closes #31