### PR TITLE
Pillow 10 Support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.6.0
     hooks:
       - id: black
 

--- a/pelican/plugins/image_process/RELEASE.md
+++ b/pelican/plugins/image_process/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+*bug*: Fix function calls to be deprecated by Pillow 10.

--- a/pelican/plugins/image_process/image_process.py
+++ b/pelican/plugins/image_process/image_process.py
@@ -169,7 +169,7 @@ def resize(i, w, h):
     elif i.mode == "1":
         i = i.convert("L")
 
-    return i.resize((int(w), int(h)), Image.LANCZOS)
+    return i.resize((int(w), int(h)), Image.Resampling.LANCZOS)
 
 
 def scale(i, w, h, upscale, inside):
@@ -215,7 +215,7 @@ def scale(i, w, h, upscale, inside):
     elif i.mode == "1":
         i = i.convert("L")
 
-    return i.resize((int(scale * iw), int(scale * ih)), Image.LANCZOS)
+    return i.resize((int(scale * iw), int(scale * ih)), Image.Resampling.LANCZOS)
 
 
 def rotate(i, degrees):
@@ -225,7 +225,7 @@ def rotate(i, degrees):
         i = i.convert("L")
 
     # rotate does not support the LANCZOS filter (Pillow 2.7.0).
-    return i.rotate(int(degrees), Image.BICUBIC, True)
+    return i.rotate(int(degrees), Image.Resampling.BICUBIC, True)
 
 
 def apply_filter(i, f):
@@ -239,8 +239,8 @@ def apply_filter(i, f):
 
 basic_ops = {
     "crop": crop,
-    "flip_horizontal": lambda i: i.transpose(Image.FLIP_LEFT_RIGHT),
-    "flip_vertical": lambda i: i.transpose(Image.FLIP_TOP_BOTTOM),
+    "flip_horizontal": lambda i: i.transpose(Image.Transpose.FLIP_LEFT_RIGHT),
+    "flip_vertical": lambda i: i.transpose(Image.Transpose.FLIP_TOP_BOTTOM),
     "grayscale": lambda i: i.convert("L"),
     "resize": resize,
     "rotate": rotate,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,8 @@ lxml = "^4.6"
 
 [tool.poetry.dev-dependencies]
 black = "^22"
-flake8 = "^3.8"
-flake8-black = "^0.2.0"
+flake8 = "^4.0"
+flake8-black = "^0.3.3"
 invoke = "^1.3"
 isort = "^5.4"
 livereload = "^2.6"


### PR DESCRIPTION
Fixes several deprecation warnings of things that will be removed in Pillow 10. Likely requires a minimum of Pillow 9 (which we bumped up to with v3 anyway). Closes #64.

Tweaks the pre-commit config for that continues to work as well.