### PR TITLE
Don't crash on empty <content> elements.

### DIFF
--- a/pelican/plugins/image_process/image_process.py
+++ b/pelican/plugins/image_process/image_process.py
@@ -300,7 +300,7 @@ def harvest_feed_images(path, context, feed):
         soup = BeautifulSoup(f, "xml")
 
         for content in soup.find_all("content"):
-            if content["type"] != "html":
+            if content["type"] != "html" or not content.string:
                 continue
 
             doc = html.unescape(content.string)


### PR DESCRIPTION
Pelican emits an empty `<content>` element for empty articles. Beautiful Soup's `string` attribute returns `None` for empty elements, not the empty string.

Fix a crash in `harvest_feed_images()` when this happens.

This is a rework of PR #62 which seems to have been corrupted by botpub.