### PR TITLE
Use `image.width/image.height` instead of `bbox`

### DIFF
--- a/pelican/plugins/image_process/image_process.py
+++ b/pelican/plugins/image_process/image_process.py
@@ -126,15 +126,13 @@ def convert_box(image, top, left, right, bottom):
     t, l, r, b (top, left, right, bottom) must be strings specifying
     either a number or a percentage.
     """
-    bbox = image.getbbox()
-    img_width = bbox[2] - bbox[0]
-    img_height = bbox[3] - bbox[1]
-
-    top = img_height * float(top[:-1]) / 100.0 if top[-1] == "%" else float(top)
-    left = img_width * float(left[:-1]) / 100.0 if left[-1] == "%" else float(left)
-    right = img_width * float(right[:-1]) / 100.0 if right[-1] == "%" else float(right)
+    top = image.height * float(top[:-1]) / 100.0 if top[-1] == "%" else float(top)
+    left = image.width * float(left[:-1]) / 100.0 if left[-1] == "%" else float(left)
+    right = (
+        image.width * float(right[:-1]) / 100.0 if right[-1] == "%" else float(right)
+    )
     if bottom[-1] == "%":
-        bottom = img_height * float(bottom[:-1]) / 100.0
+        bottom = image.height * float(bottom[:-1]) / 100.0
     else:
         bottom = float(bottom)
 
@@ -178,9 +176,8 @@ def scale(i, w, h, upscale, inside):
     If inside is True, the resulting image will not be larger than the
     dimensions specified, else it will not be smaller.
     """
-    bbox = i.getbbox()
-    iw = bbox[2] - bbox[0]
-    ih = bbox[3] - bbox[1]
+    iw = i.width
+    ih = i.height
 
     if w == "None":
         w = 1.0


### PR DESCRIPTION
Replace image width/height calculation based on image.getbbox() with the actual image.width and image.height properties. This fixes image operations for images with empty margins.

Explanation: Previously, the code used the values returned by `Image.getbbox()` to calculate image dimensions. However, `getbbox()` “Calculates the bounding box of the non-zero regions in the image.” As a result, this accidentally works for images that don’t have zero regions, but it fails for images that do have empty/black margins like this example:

![01](https://github.com/user-attachments/assets/44130d9e-af2a-4e68-9791-5d5157ff807c)

For such images, the resize operations distort the image, as the scale operation is not calculated on the actual image dimensions, but on the non-empty area.

Since the bbox is not actually required here, this patch replaces the width/height calculation based on `getbbox()` with the much simpler width/height properties of the image object.

For most images, this change should not result in any different output, and all tests still pass.