### PR TITLE
Update plugin with upstream template changes

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/getpelican/cookiecutter-pelican-plugin",
-  "commit": "94970ab900aed538f451686a2eb51188dbfd1a28",
+  "commit": "02d8421338ac53e1422bfe2bee92d0debfab3de4",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -20,7 +20,8 @@
       "tests_exist": true,
       "python_version": ">=3.8.1,<4.0",
       "pelican_version": ">=4.5",
-      "_template": "https://github.com/getpelican/cookiecutter-pelican-plugin"
+      "_template": "https://github.com/getpelican/cookiecutter-pelican-plugin",
+      "_commit": "02d8421338ac53e1422bfe2bee92d0debfab3de4"
     }
   },
   "directory": null

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install Exiftool
         run: sudo apt install libimage-exiftool-perl
@@ -41,6 +43,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python & PDM
         uses: pdm-project/setup-pdm@v4
@@ -75,8 +79,7 @@ jobs:
       - name: Check release
         id: check_release
         run: |
-          python -m pip install autopub httpx
-          python -m pip install https://github.com/scikit-build/github-release/archive/master.zip
+          python -m pip install autopub[github]
           autopub check
 
       - name: Publish

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ ci:
 # See https://pre-commit.com/hooks.html for info on hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -21,7 +21,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.1
+    rev: v0.9.9
     hooks:
       - id: ruff
       - id: ruff-format

--- a/pelican/plugins/image_process/image_process.py
+++ b/pelican/plugins/image_process/image_process.py
@@ -328,8 +328,7 @@ def harvest_images_in_fragment(fragment, settings):
 
         elif not isinstance(d, dict):
             raise TypeError(
-                f"Derivative {derivative} definition not handled"
-                "(must be list or dict)"
+                f"Derivative {derivative} definition not handled (must be list or dict)"
             )
 
         elif "type" not in d:

--- a/pelican/plugins/image_process/test_image_process.py
+++ b/pelican/plugins/image_process/test_image_process.py
@@ -167,8 +167,7 @@ def test_path_normalization(mocker, orig_src, orig_img, new_src, new_img):
     settings = get_settings(IMAGE_PROCESS_DIR="derivatives")
 
     img_tag_orig = (
-        '<img class="test image-process image-process-crop test2" '
-        f'src="{orig_src}"/>'
+        f'<img class="test image-process image-process-crop test2" src="{orig_src}"/>'
     )
 
     img_tag_processed = harvest_images_in_fragment(img_tag_orig, settings)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,16 +15,16 @@ classifiers = [
     "License :: OSI Approved :: GNU Affero General Public License v3",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Multimedia :: Graphics",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires-python = ">=3.8.1,<4.0"
+requires-python = "~=3.9"
 dependencies = [
     "pelican>=4.5",
     "beautifulsoup4>=4.9",
@@ -33,21 +33,21 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/pelican-plugins/image-process"
+"Homepage" = "https://github.com/pelican-plugins/image-process"
 "Issue Tracker" = "https://github.com/pelican-plugins/image-process/issues"
-Funding = "https://donate.getpelican.com/"
+"Changelog" = "https://github.com/pelican-plugins/image-process/blob/main/CHANGELOG.md"
+"Funding" = "https://donate.getpelican.com/"
 
 [project.optional-dependencies]
 markdown = ["markdown>=3.4"]
 
-[tool.pdm]
-
-[tool.pdm.dev-dependencies]
+[dependency-groups]
 lint = [
     "invoke>=2.2",
-    "ruff>=0.6.0,<0.7.0",
+    "ruff>=0.9.9,<1.0.0",
 ]
 test = [
+    "invoke>=2.2",
     "markdown>=3.4",
     "pytest>=7.0",
     "pytest-cov>=4.0",

--- a/tasks.py
+++ b/tasks.py
@@ -47,20 +47,22 @@ def format(c, check=False, diff=False):
 
 
 @task
-def ruff(c, fix=False, diff=False):
+def ruff(c, concise=False, fix=False, diff=False):
     """Run Ruff to ensure code meets project standards."""
-    diff_flag, fix_flag = "", ""
+    concise_flag, fix_flag, diff_flag = "", "", ""
+    if concise:
+        concise_flag = "--output-format=concise"
     if fix:
         fix_flag = "--fix"
     if diff:
         diff_flag = "--diff"
-    c.run(f"{CMD_PREFIX}ruff check {diff_flag} {fix_flag} .", pty=PTY)
+    c.run(f"{CMD_PREFIX}ruff check {concise_flag} {diff_flag} {fix_flag} .", pty=PTY)
 
 
 @task
-def lint(c, fix=False, diff=False):
+def lint(c, concise=False, fix=False, diff=False):
     """Check code style via linting tools."""
-    ruff(c, fix=fix, diff=diff)
+    ruff(c, concise=concise, fix=fix, diff=diff)
     format(c, check=(not fix), diff=diff)
 
 


### PR DESCRIPTION
Primary change is dropping support for EOL Python 3.8 and adding Python 3.13 to the CI test matrix.

Also fixes #75.