### PR TITLE
Preserve whitespace when rewriting content.

### DIFF
--- a/pelican/plugins/image_process/image_process.py
+++ b/pelican/plugins/image_process/image_process.py
@@ -287,7 +287,7 @@ def harvest_feed_images(path, context, feed):
     set_default_settings(context)
 
     with open(path, "r+", encoding=context["IMAGE_PROCESS_ENCODING"]) as f:
-        soup = BeautifulSoup(f, "xml")
+        soup = BeautifulSoup(f, "xml", preserve_whitespace_tags={"rss", "feed"})
 
         for content in soup.find_all("content"):
             if content["type"] != "html" or not content.string:
@@ -303,7 +303,7 @@ def harvest_feed_images(path, context, feed):
 
 def harvest_images_in_fragment(fragment, settings):
     parser = settings.get("IMAGE_PROCESS_PARSER", "html.parser")
-    soup = BeautifulSoup(fragment, parser)
+    soup = BeautifulSoup(fragment, parser, preserve_whitespace_tags={"html"})
 
     copy_exif_tags = settings.get("IMAGE_PROCESS_COPY_EXIF_TAGS", False)
     if copy_exif_tags:


### PR DESCRIPTION
This PR comes from the discussion in issue #84. It makes Image Process preserves the original indentation of the content. This improves the HTML output by keeping the indentation present in the theme template files.

It does not really solve the reported issue (which I understand is about the feeds), though, as the feeds do not seem to be initially indented.