### PR TITLE
Skip images that Pillow can't process

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+- Skip images that Pillow can't process, and let Pelican look for them at their original, unprocessed locations

--- a/pelican/plugins/image_process/image_process.py
+++ b/pelican/plugins/image_process/image_process.py
@@ -448,13 +448,21 @@ def process_img_tag(img, settings, derivative):
     path = compute_paths(img["src"], settings, derivative)
     process = settings["IMAGE_PROCESS"][derivative]
 
-    img["src"] = posixpath.join(path.base_url, path.filename)
     destination = os.path.join(str(path.base_path), path.filename)
 
     if not isinstance(process, list):
         process = process["ops"]
 
-    image_size = process_image((path.source, destination, process), settings)
+    try:
+        image_size = process_image((path.source, destination, process), settings)
+    except (UnidentifiedImageError, FileNotFoundError):
+        image_size = None
+    else:
+        # Only try and find the image at the new location (in the generated
+        # site) if we've processed the image successfully. Otherwise, default
+        # to the original location
+        img["src"] = posixpath.join(path.base_url, path.filename)
+
     if image_size:
         if "width" not in img.attrs:
             img["width"] = image_size[0]
@@ -749,8 +757,9 @@ def process_image(image, settings):
 
         try:
             i = try_open_image(image[0])
-        except (UnidentifiedImageError, FileNotFoundError):
-            return None
+        except (UnidentifiedImageError, FileNotFoundError):  # noqa: TRY203
+            # return None
+            raise
 
         for step in image[2]:
             if callable(step):

--- a/pelican/plugins/image_process/image_process.py
+++ b/pelican/plugins/image_process/image_process.py
@@ -721,9 +721,7 @@ def try_open_image(path):
     try:
         i = Image.open(path)
     except UnidentifiedImageError:
-        logger.warning(
-            f'{LOG_PREFIX} Source image "{path}" is not supported by Pillow.'
-        )
+        logger.info(f'{LOG_PREFIX} Source image "{path}" is not supported by Pillow.')
         raise
     except FileNotFoundError:
         logger.warning(f'{LOG_PREFIX} Source image "{path}" not found.')


### PR DESCRIPTION
Current, if there's an image that Pillow can't process (e.g. an svg files), the plugin prints an error message but still changes the *img src* location. This means that the image in the final site won't load.

This change makes it to the *img src* is only changed if the image is processed without raising an error.

---

Ruff complains about the immediately re-raised error at about Line 760, but I've kept it to make it more obvious that the errors are expected to be raised at that location, and to make it clear that the function might be exited at that location. I've applied `#noqa: TRY203` to that line to silence this particular warning.

Ruff prints the following:

```
TRY203 Remove exception handler; error is immediately re-raised
   --> pelican\plugins\image_process\image_process.py:760:9
    |
758 |           try:
759 |               i = try_open_image(image[0])
760 | /         except (UnidentifiedImageError, FileNotFoundError):
761 | |             # return None
762 | |             raise
    | |_________________^
763 |
764 |           for step in image[2]:
    |
```

---

Edit: I've changed the log level for skipped images to `INFO` (but left unfound images at `WARNING`). Partly, this is because I publish my site with fatal warnings, and so don't want it to break here.
